### PR TITLE
Update runtime version

### DIFF
--- a/templates/copy_lambda.template
+++ b/templates/copy_lambda.template
@@ -249,7 +249,7 @@
                         "Arn"
                     ]
                 },
-                "Runtime": "nodejs6.10",
+                "Runtime": "nodejs8.10",
                 "Timeout": "120",
                 "Code": {
                     "S3Bucket": {


### PR DESCRIPTION
Node.js 6.10 is no longer supported as lambda runtime